### PR TITLE
avoid unnecessary copying

### DIFF
--- a/src/TableReader.jl
+++ b/src/TableReader.jl
@@ -487,7 +487,7 @@ function readdlm_internal(stream::TranscodingStream, params::ParserParameters)
                         "try larger chunkbits or chunkbits = 0 to disable chunking")))
                 end
                 n_rows = length(col)
-                if T <: S
+                if U <: S
                     resize!(col, n_rows + n_new_rows)
                 else
                     col = copyto!(Vector{U}(undef, n_rows + n_new_rows), 1, col, 1, n_rows)


### PR DESCRIPTION
This fixes #36.

```julia
using TableReader
path = "Performance_2000Q1.txt"
for _ in 1:3
    GC.gc()
    @time readcsv(path, delim = '|', hasheader = false)
end
```

```
~/w/TableReader (master|…) $ julia test.jl
 40.523711 seconds (14.38 M allocations: 69.604 GiB, 30.42% gc time)
 33.779476 seconds (10.80 M allocations: 69.381 GiB, 37.23% gc time)
 34.421806 seconds (10.80 M allocations: 69.381 GiB, 36.56% gc time)

~/w/TableReader (fix-copy|…) $ julia test.jl
 11.899252 seconds (14.32 M allocations: 5.864 GiB, 9.90% gc time)
  9.066965 seconds (10.80 M allocations: 5.627 GiB, 15.94% gc time)
  9.026347 seconds (10.80 M allocations: 5.627 GiB, 15.82% gc time)
```